### PR TITLE
Multiple fixes

### DIFF
--- a/Hotelsnl/Sniffs/Commenting/FunctionCommentSniff.php
+++ b/Hotelsnl/Sniffs/Commenting/FunctionCommentSniff.php
@@ -335,8 +335,8 @@ class Hotelsnl_Sniffs_Commenting_FunctionCommentSniff implements PHP_CodeSniffer
                 }
 
                 $spacing = substr_count($see->getWhitespaceBeforeContent(), ' ');
-                if ($spacing !== 4) {
-                    $error = '@see tag indented incorrectly; expected 4 spaces but found %s';
+                if ($spacing !== 1) {
+                    $error = '@see tag indented incorrectly; expected 1 space but found %s';
                     $data  = array($spacing);
                     $this->currentFile->addError($error, $errorPos, 'SeeIndent', $data);
                 }

--- a/Hotelsnl/Sniffs/Commenting/LongConditionClosingCommentSniff.php
+++ b/Hotelsnl/Sniffs/Commenting/LongConditionClosingCommentSniff.php
@@ -46,6 +46,8 @@ class Hotelsnl_Sniffs_Commenting_LongConditionClosingCommentSniff implements PHP
      */
     protected $lineLimit = 20;
 
+    protected $lastFoundLine = 0;
+
 
     /**
      * Returns an array of tokens this test wants to listen for.
@@ -79,8 +81,7 @@ class Hotelsnl_Sniffs_Commenting_LongConditionClosingCommentSniff implements PHP
 
         $expected = '<?php';
         $comment  = $phpcsFile->findNext(array(T_COMMENT), $stackPtr, null, false);
-
-        if (trim($tokens[$comment]['content']) !== $expected && $tokens[$comment]['level'] === 1) {
+        if (trim($tokens[$comment]['content']) !== $expected && $tokens[$comment]['level'] === 1 && $tokens[$comment]['line'] === $this->lastFoundLine && $tokens[$stackPtr]['line'] === $tokens[$comment]['line']) {
             $found = trim($tokens[$comment]['content']);
             $error = 'Do not use closing comments!';
             $data  = array(
@@ -90,7 +91,7 @@ class Hotelsnl_Sniffs_Commenting_LongConditionClosingCommentSniff implements PHP
             $phpcsFile->addError($error, $stackPtr, 'Invalid', $data);
             return;
         }
-
+        $this->lastFoundLine = $tokens[$comment]['line'];
     }//end process()
 
 

--- a/Hotelsnl/Sniffs/WhiteSpace/FunctionSpacingSniff.php
+++ b/Hotelsnl/Sniffs/WhiteSpace/FunctionSpacingSniff.php
@@ -79,12 +79,12 @@ class Hotelsnl_Sniffs_WhiteSpace_FunctionSpacingSniff implements PHP_CodeSniffer
             }
         }
 
+        $nextContent = $phpcsFile->findNext(array(T_WHITESPACE), ($nextLineToken + 1), null, true);
         if (is_null($nextLineToken) === true) {
             // Never found the next line, which means
             // there are 0 blank lines after the function.
             $foundLines = 0;
         } else {
-            $nextContent = $phpcsFile->findNext(array(T_WHITESPACE), ($nextLineToken + 1), null, true);
             if ($nextContent === false) {
                 // We are at the end of the file.
                 $foundLines = 0;
@@ -93,7 +93,7 @@ class Hotelsnl_Sniffs_WhiteSpace_FunctionSpacingSniff implements PHP_CodeSniffer
             }
         }
 
-        if ($foundLines !== 1) {
+        if ($foundLines !== 1 && $nextContent !== false) {
             $error = 'Expected 1 blank lines after function; %s found';
             $data  = array($foundLines);
             $phpcsFile->addError($error, $closer, 'After', $data);


### PR DESCRIPTION
- only check and display valid end comments of block statement
- no blank line after last function
- better @see comment tag
